### PR TITLE
Zeph main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /bin/*
 /BinTemp/*
 
+# Ignore Code/SDKs now it's not a submodule
+Code/SDKs/*
+
 # Ignore auto generated cmake and waf solutions
 /Solutions/*
 

--- a/Code/CryEngine/CryAction/ActionMapManager.cpp
+++ b/Code/CryEngine/CryAction/ActionMapManager.cpp
@@ -219,17 +219,23 @@ bool CActionMapManager::InitActionMaps(const char* filename)
 			XmlNodeRef platform = platformsNode->findChild(GetISystem()->GetPlatformOS()->GetPlatformName());
 			if (platform)
 			{
-				BYTE devices(eAID_KeyboardMouse | eAID_XboxPad | eAID_PS4Pad | eAID_OculusTouch);
+				if (!platform->haveAttr("keyboard"))
+					CryWarning(VALIDATOR_MODULE_GAME, VALIDATOR_WARNING, "CActionMapManager::InitActionMaps:  Platform '%s' tag does not contain attribute keyboard, device will not be mapped", GetISystem()->GetPlatformOS()->GetPlatformName());
+				if (!platform->haveAttr("xboxpad"))
+					CryWarning(VALIDATOR_MODULE_GAME, VALIDATOR_WARNING, "CActionMapManager::InitActionMaps:  Platform '%s' tag does not contain attribute xboxpad, device will not be mapped", GetISystem()->GetPlatformOS()->GetPlatformName());
+				if (!platform->haveAttr("ps4pad"))
+					CryWarning(VALIDATOR_MODULE_GAME, VALIDATOR_WARNING, "CActionMapManager::InitActionMaps:  Platform '%s' tag does not contain attribute ps4pad, device will not be mapped", GetISystem()->GetPlatformOS()->GetPlatformName());
+				if (!platform->haveAttr("oculustouch"))
+					CryWarning(VALIDATOR_MODULE_GAME, VALIDATOR_WARNING, "CActionMapManager::InitActionMaps:  Platform '%s' tag does not contain attribute oculustouch, device will not be mapped", GetISystem()->GetPlatformOS()->GetPlatformName());
 
-				if (!strcmp(platform->getAttr("keyboard"), "0"))      devices &= ~eAID_KeyboardMouse;
-				if (!strcmp(platform->getAttr("xboxpad"), "0"))       devices &= ~eAID_XboxPad;
-				if (!strcmp(platform->getAttr("ps4pad"), "0"))        devices &= ~eAID_PS4Pad;
-				if (!strcmp(platform->getAttr("oculustouch"), "0"))   devices &= ~eAID_OculusTouch;
-
-				if (devices & eAID_KeyboardMouse) AddInputDeviceMapping(eAID_KeyboardMouse, "keyboard");
-				if (devices & eAID_XboxPad)       AddInputDeviceMapping(eAID_XboxPad, "xboxpad");
-				if (devices & eAID_PS4Pad)        AddInputDeviceMapping(eAID_PS4Pad, "ps4pad");
-				if (devices & eAID_OculusTouch)   AddInputDeviceMapping(eAID_OculusTouch, "oculustouch");
+				if (strcmp(platform->getAttr("keyboard"), "1"))
+					AddInputDeviceMapping(eAID_KeyboardMouse, "keyboard");
+				if (strcmp(platform->getAttr("xboxpad"), "1"))
+					AddInputDeviceMapping(eAID_XboxPad, "xboxpad");
+				if (strcmp(platform->getAttr("ps4pad"), "1"))
+					AddInputDeviceMapping(eAID_PS4Pad, "ps4pad");
+				if (strcmp(platform->getAttr("oculustouch"), "1"))
+					AddInputDeviceMapping(eAID_OculusTouch, "oculustouch");
 
 				SetLoadFromXMLPath(filename);
 				if (LoadFromXML(rootNode))

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# CRYENGINE
+This repository houses the source code for CRYENGINE.
+
+In order to compile, you will need to download the SDKs for the particular release you are trying to build. They can be found [here](https://github.com/CRYTEK-CRYENGINE/CRYENGINE/releases).
+
+Instructions on getting started with git can be found [here](http://docs.cryengine.com/display/CEPROG/Getting+Started+with+git), along with details on working with launcher projects and git source code.
+
+# Terminology
+Development takes place primarily in the "main" branch. The stabilisation branch is used for fixing bugs in the run-up to release, and the release branch provides stable snapshots of the engine.
+
+To prepare for a major (feature) release, we integrate "main" into "stabilisation", and then continue fixing bugs in "stabilisation". To prepare for a minor (stability) release, individual changes from 'main are integrated directly into "stabilisation". In each case, when the release is deemed ready, "stabilisation" is integrated to "release".
+
+# License
+The source code in this repository is governed by the CRYENGINE license agreement, which can be read in full at [https://www.cryengine.com/ce-terms](https://www.cryengine.com/ce-terms).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # CRYENGINE
 This repository houses the source code for CRYENGINE.
 
+Instructions on getting started with git can be found [here](http://docs.cryengine.com/display/CEPROG/Getting+Started+with+git), along with details on working with launcher projects and git source code.
+
+## Building
+
 In order to compile, you will need to download the SDKs for the particular release you are trying to build. They can be found [here](https://github.com/CRYTEK-CRYENGINE/CRYENGINE/releases).
 
-Instructions on getting started with git can be found [here](http://docs.cryengine.com/display/CEPROG/Getting+Started+with+git), along with details on working with launcher projects and git source code.
+Extract the archive and move the SDK directory to the **Code** folder and rename it to **SDKs**. 
+
+To compile the engine the provided WAF has to be used. See [here](http://docs.cryengine.com/display/CEPROG/Getting+Started+with+WAF) for more information.
 
 # Terminology
 Development takes place primarily in the "main" branch. The stabilisation branch is used for fixing bugs in the run-up to release, and the release branch provides stable snapshots of the engine.


### PR DESCRIPTION
When GameZero was released, I noticed that controller devices were getting mapped despite a typo in the action profile xml.  The existing source code is set up to automatically map devices unless the xml specifically opts out.  That's fine, I guess, but every other event system within the engine requires you to opt into receiving events.  This change brings the Action Map Manager's initialization in line with the rest of the engine in that regard and provides warnings in the log file for designers who make typos.

If this PR is accepted, the GameZero default profile would need an Oculus Touch attribute for the PC platform.  A warning will be generated in game.log similar to the following:
<08:30:26> [Warning] CActionMapManager::InitActionMaps:  Platform 'PC' tag does not contain attribute oculustouch, device will not be mapped