### PR TITLE
!B (System) Wrong warning missing thread configuration when only common configuration is defined

### DIFF
--- a/Code/CryEngine/CrySystem/ThreadConfigManager.cpp
+++ b/Code/CryEngine/CrySystem/ThreadConfigManager.cpp
@@ -106,11 +106,16 @@ bool CThreadConfigManager::LoadConfig(const char* pcPath)
 	sCurThreadConfigFilename = pcPath;
 	const char* strPlatformId = IdentifyPlatform();
 	CryFixedStringT<32> tmpPlatformStr;
-	bool retValue = false;
+	bool retValueCommon = false;
+	bool retValueCPU = false;
 
 	// Try load common platform settings
 	tmpPlatformStr.Format("%s_Common", strPlatformId);
-	LoadPlatformConfig(xmlRoot, tmpPlatformStr.c_str());
+	retValueCommon = LoadPlatformConfig(xmlRoot, tmpPlatformStr.c_str());
+	if (retValueCommon)
+	{
+		CryLogAlways("<ThreadConfigInfo>: Thread profile loaded: \"%s\" (%s)  ", tmpPlatformStr.c_str(), pcPath);
+	}
 
 #if defined(CRY_PLATFORM_DESKTOP)
 	// Handle PC specifically as we do not know the core setup of the executing machine.
@@ -122,14 +127,14 @@ bool CThreadConfigManager::LoadConfig(const char* pcPath)
 	for (; i > 0; --i)
 	{
 		tmpPlatformStr.Format("%s_%i", strPlatformId, i);
-		retValue = LoadPlatformConfig(xmlRoot, tmpPlatformStr.c_str());
-		if (retValue)
+		retValueCPU = LoadPlatformConfig(xmlRoot, tmpPlatformStr.c_str());
+		if (retValueCPU)
 		{
 			break;
 		}
 	}
 
-	if (retValue && i != numCPUs)
+	if (retValueCPU && i != numCPUs)
 	{
 		CryWarning(VALIDATOR_MODULE_SYSTEM, VALIDATOR_WARNING, "<ThreadConfigInfo>: (%s: %u core) Unable to find platform config \"%s\". Next valid config found was %s_%u.",
 		           strPlatformId, numCPUs, tmpPlatformStr.c_str(), strPlatformId, i);
@@ -137,22 +142,23 @@ bool CThreadConfigManager::LoadConfig(const char* pcPath)
 
 #else
 	tmpPlatformStr.Format("%s", strPlatformId);
-	retValue = LoadPlatformConfig(xmlRoot, strPlatformId);
+	retValueCPU = LoadPlatformConfig(xmlRoot, strPlatformId);
 #endif
 
 	// Print out info
-	if (retValue)
+	if (retValueCPU)
 	{
 		CryLogAlways("<ThreadConfigInfo>: Thread profile loaded: \"%s\" (%s)  ", tmpPlatformStr.c_str(), pcPath);
 	}
-	else
+	
+	if ((retValueCommon == false) && (retValueCPU == false))
 	{
 		// Could not find any matching platform
 		CryWarning(VALIDATOR_MODULE_SYSTEM, VALIDATOR_WARNING, "<ThreadConfigInfo>: Active platform identifier string \"%s\" not found in config \"%s\".", strPlatformId, sCurThreadConfigFilename);
 	}
 
 	sCurThreadConfigFilename = "";
-	return retValue;
+	return (retValueCommon || retValueCPU);
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If only common configuration is defined in the thread configuration file, the sytem was loading it and then trying to load some CPU dependant configuration. If not found, it was showing a warning about platform not being defined. Common configuration was loaded but ignored when checking the loaded condition.